### PR TITLE
Bugfix-extended-compond-selector

### DIFF
--- a/assets/stylesheets/_summary.scss
+++ b/assets/stylesheets/_summary.scss
@@ -46,7 +46,7 @@
 $hmpo-summary-list: true !default;
 @if $hmpo-summary-list {
     .govuk-summary-list {
-        @extend .govuk-summary-list.govuk-summary-list--confirmation;
+        @extend .govuk-summary-list--confirmation;
     }
 }
 


### PR DESCRIPTION
When upgrading `4.6.0` to `5.0.3` I've found I'm unable to build using `sass 1.43.3`.

It looks like a change was introduced to use extend with a compound selector. The suggested solution provided by the compiler is to change the usage of extend from this...

`    .govuk-summary-list {
        @extend .govuk-summary-list.govuk-summary-list--confirmation;
    }
`
to this
`    .govuk-summary-list {
        @extend .govuk-summary-list, .govuk-summary-list--confirmation;
    }
`
    
This fixes the compiler issue.
Ref: https://sass-lang.com/documentation/at-rules/extend#disallowed-selectors