### PR TITLE
Move `cookieBanner` to follow Design System guidance

### DIFF
--- a/components/hmpo-template.njk
+++ b/components/hmpo-template.njk
@@ -14,6 +14,15 @@
     {{ (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} {{ "– " + govukServiceName | safe if govukServiceName }} – GOV.UK
 {% endblock %}
 
+{% block bodyStart %}
+    {% block cookieBanner %}
+        {% from "hmpo-cookie-banner/macro.njk" import hmpoCookieBanner %}
+        {{ hmpoCookieBanner({
+            html: translate("govuk.cookieBanner")
+        }) }}
+    {% endblock %}
+{% endblock %}
+
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 {% block skipLink %}
     {{ govukSkipLink({
@@ -23,12 +32,6 @@
 {% endblock %}
 
 {% block header %}
-    {% block cookieBanner %}
-        {% from "hmpo-cookie-banner/macro.njk" import hmpoCookieBanner %}
-        {{ hmpoCookieBanner({
-            html: translate("govuk.cookieBanner")
-        }) }}
-    {% endblock %}
     {% block govukHeader %}
         {{ govukHeader({
             assetsPath: assetPath + '/images',


### PR DESCRIPTION
Afternoon 👋 

Hope this PR is useful!

A service I'm working on has recently been flagged for inserting the [Skip link](https://design-system.service.gov.uk/components/skip-link/) component _before_ the [Cookie banner](https://design-system.service.gov.uk/components/cookie-banner/). Until today, we hadn't realised the Design System guidance says to use the [`bodyStart` block](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/template.njk#L32) not the [`header` block](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/template.njk#L41).

Problem is, we're extending **hmpo-template.njk** and using the `cookieBanner` block to insert the **govukCookieBanner** component (versus **hmpoCookieBanner**) BUT it uses the `header` block.

Here's the guidance we were shown. Makes sense!

>[**Cookie banner**](https://design-system.service.gov.uk/components/cookie-banner/#how-it-works)
>Position the cookie banner after the opening `<body>` tag and before the ’skip to main content‘ link. If you’re using the Nunjucks page template, use the `bodyStart` block.

Thanks again for the fab work