### PR TITLE
LIME-254 - "or" divider on licence issuer screen displaying as English (Welsh Translation).

### DIFF
--- a/lib/globals.js
+++ b/lib/globals.js
@@ -138,6 +138,9 @@ let globals = {
                     attributes: { id: item.id + '-label' }
                 }, item.label);
             }
+            if (item.divider) {
+                item.divider = translate(contentKey + '.items.' + item.divider + '.label');
+            }
 
             // override id of first item to be field name for accessibility
             if (setIdsBasedOnValues && index === 0) item.id = params.id;


### PR DESCRIPTION
## Proposed changes

### What changed

- Welsh translation added for radio button dividers
See:  https://github.com/alphagov/di-ipv-cri-dl-front/pull/78

### Why did it change

- Translation was not supported prior to this ticket.

### Issue tracking

- [LIME-254](https://govukverify.atlassian.net/browse/LIME-254)


[LIME-254]: https://govukverify.atlassian.net/browse/LIME-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://user-images.githubusercontent.com/107932230/218072986-e5fa7abe-b19f-493d-b25c-440dc9f46419.png)
