### PR TITLE
update crown logo in govHeader

### DIFF
--- a/components/hmpo-template.njk
+++ b/components/hmpo-template.njk
@@ -36,7 +36,8 @@
             serviceName: govukServiceName,
             navigation: govukNavigation,
             serviceUrl: govukServiceUrl or "/",
-            containerClasses: "govuk-width-container"
+            containerClasses: "govuk-width-container",
+            useTudorCrown: true
         }) }}
     {% endblock %}
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "chai": "^4.3.7",
         "eslint": "^8.44.0",
-        "govuk-frontend": "^4.6.0",
+        "govuk-frontend": "^4.8.0",
         "hmpo-nunjucks-test": "^1.4.1",
         "husky": "^2.7.0",
         "mocha": "^10.2.0",
@@ -2580,9 +2580,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "dev": true,
       "engines": {
         "node": ">= 4.2.0"
@@ -7933,9 +7933,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "dev": true
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "chai": "^4.3.7",
     "eslint": "^8.44.0",
-    "govuk-frontend": "^4.6.0",
+    "govuk-frontend": "^4.8.0",
     "hmpo-nunjucks-test": "^1.4.1",
     "husky": "^2.7.0",
     "mocha": "^10.2.0",


### PR DESCRIPTION
- enable new tudor logo in gov header component
- update package.json with latest version of govuk-frontend 4.8.0