### PR TITLE
Update Invalid html syntax and remove IE8 support from hmpo support

### DIFF
--- a/components/hmpo-form/macro.njk
+++ b/components/hmpo-form/macro.njk
@@ -13,7 +13,7 @@
         {{- params.content if params.content }}{{- caller() if caller }}
         {%- set csrfToken = ctx("csrf-token") %}
         {%- if csrfToken %}
-            <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}" />
+            <input type="hidden" name="x-csrf-token" value="{{ csrfToken }}">
         {%- endif %}
     </form>
 {% endmacro %}

--- a/components/hmpo-form/macro.njk
+++ b/components/hmpo-form/macro.njk
@@ -6,11 +6,10 @@
         action: params.action | default(ctx("action")) | default(""),
         method: params.method | default("POST"),
         autocomplete: "off",
-        novalidate: "true",
         spellcheck: "false"
     }) %}
 
-    <form {%- for attribute, value in attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+    <form {%- for attribute, value in attributes %} {{ attribute }}="{{ value }}" novalidate {% endfor -%}>
         {{- params.content if params.content }}{{- caller() if caller }}
         {%- set csrfToken = ctx("csrf-token") %}
         {%- if csrfToken %}

--- a/components/hmpo-form/spec.macro.js
+++ b/components/hmpo-form/spec.macro.js
@@ -58,4 +58,11 @@ describe('hmpoForm', () => {
         const $csrf = $('input');
         expect($csrf.length).to.equal(0);
     });
+
+    it('renders novalidate attribute', () => {
+        const $ = render({ component: 'hmpoForm', params: {}, ctx: true }, locals);
+        const $component = $('form');
+        expect($component.attr('novalidate')).to.equal('');
+    });
+
 });

--- a/components/hmpo-template.njk
+++ b/components/hmpo-template.njk
@@ -6,8 +6,8 @@
 {% set assetPath = assetPath | default(assetsPath) | default("/public") %}
 
 {% block head %}
-    <!--[if lte IE 8]><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheetIE8 | default("application-ie8.css") }}" rel="stylesheet" type="text/css" /><![endif]-->
-    <!--[if gt IE 8]><!--><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheet | default("application.css") }}" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+    <!--[if lte IE 8]><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheetIE8 | default("application-ie8.css") }}" rel="stylesheet" type="text/css"><![endif]-->
+    <!--[if gt IE 8]><!--><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheet | default("application.css") }}" media="all" rel="stylesheet" type="text/css"><!--<![endif]-->
 {% endblock %}
 
 {% block pageTitle %}

--- a/components/hmpo-template.njk
+++ b/components/hmpo-template.njk
@@ -5,11 +5,6 @@
 {% set govukServiceName = translate(govukServiceNameKey or "govuk.serviceName") %}
 {% set assetPath = assetPath | default(assetsPath) | default("/public") %}
 
-{% block head %}
-    <!--[if lte IE 8]><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheetIE8 | default("application-ie8.css") }}" rel="stylesheet" type="text/css"><![endif]-->
-    <!--[if gt IE 8]><!--><link href="{{assetPath}}/stylesheets/{{ applicationStyleSheet | default("application.css") }}" media="all" rel="stylesheet" type="text/css"><!--<![endif]-->
-{% endblock %}
-
 {% block pageTitle %}
     {{ (translate("govuk.error", { default: "Error" }) + ": ") if errorlist.length }}{{ hmpoTitle | safe }} {{ "– " + govukServiceName | safe if govukServiceName }} – GOV.UK
 {% endblock %}


### PR DESCRIPTION
Best to review each commit separately. 

Addresses a couple issues raised by W3C HTML Validator and removes mentions of IE8 and support for it as GOV.UK Frontend v5+ does not support IE let alone IE8 https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/browser-support.md#how-we-provide-support-for-different-browsers 