### PR TITLE
Add File Upload Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,27 @@ module.exports = {
 
 When any field on a page has `type: 'file-upload'`, `hmpoForm` will automatically add `enctype="multipart/form-data"`.
 
+#### File upload label sizing
+
+When `hmpoField` renders a `file-upload` field, it does not force the shared default label size class (`govuk-label--m` / `govuk-label--s`). This keeps the GOV.UK file upload label styling as the default.
+
+You can still customise label sizing per field by setting `label.classes` in your field config:
+
+```js
+// fields.js
+module.exports = {
+  applicantPassport: {
+    type: 'file-upload',
+    label: {
+      classes: 'govuk-label--m'
+    },
+    attributes: {
+      accept: 'image/jpeg,image/png,application/pdf'
+    }
+  }
+}
+```
+
 #### Task list usage
 
 Define the field with a `type` of `task-list`, a `statuses` map, and an array of `tasks`:

--- a/README.md
+++ b/README.md
@@ -247,6 +247,26 @@ Components can be called as macros:
 
 - `hmpoTaskList(ctx, params, fieldName)`: Renders a GOV.UK task list showing task titles, status (completed/incomplete), and href links. All labels and status text are resolved from locale strings using the provided field name. Used for displaying application progress or workflow steps in a display-only format.
 
+- `hmpoFileUpload(ctx, params, base)`: Renders a GOV.UK file upload input, including translated label and hint text, plus validation error messaging.
+
+#### File upload field type usage
+
+Define a field with a `type` of `file-upload` to render it via `hmpoField`:
+
+```js
+// fields.js
+module.exports = {
+  applicantPassport: {
+    type: 'file-upload',
+    attributes: {
+      accept: 'image/jpeg,image/png,application/pdf'
+    }
+  }
+}
+```
+
+When any field on a page has `type: 'file-upload'`, `hmpoForm` will automatically add `enctype="multipart/form-data"`.
+
 #### Task list usage
 
 Define the field with a `type` of `task-list`, a `statuses` map, and an array of `tasks`:

--- a/components/hmpo-all.njk
+++ b/components/hmpo-all.njk
@@ -19,3 +19,4 @@
 {% include "hmpo-textarea/macro.njk" %}
 {% include "hmpo-warning-text/macro.njk" %}
 {% include "hmpo-sidebar/macro.njk" %}
+{% include "hmpo-file-upload/macro.njk" %}

--- a/components/hmpo-field/macro.njk
+++ b/components/hmpo-field/macro.njk
@@ -41,6 +41,10 @@
     {%- elif field.type == "task-list" %}
         {% from "../hmpo-task-list/macro.njk" import hmpoTaskList %}
         {{ hmpoTaskList(ctx, field, fieldName) }}
+    {%- elif field.type == "file-upload" %}
+        {% from "../hmpo-file-upload/macro.njk" import hmpoFileUpload %}
+        {% set labelClass = null %}
+        {% set component = hmpoFileUpload %}
     {%- endif %}
 
     {%- if component %}

--- a/components/hmpo-file-upload/macro.njk
+++ b/components/hmpo-file-upload/macro.njk
@@ -1,5 +1,8 @@
 {% macro hmpoFileUpload(ctx, params, base) %}
     {%- set params = hmpoGetParams(ctx, params, base) %}
+    {%- set attributes = hmpoGetAttributes(ctx, params, {}) %}
+    {%- set inputId = attributes.id if attributes.id else params.id %}
+    {%- set attributes = attributes | delete("id") if attributes.id else attributes %}
 
     {%- set pageHeading = {
         isPageHeading: true,
@@ -7,18 +10,18 @@
     } if params.isPageHeading %}
 
     {%- set args = {
-        id: params.id,
+        id: inputId,
         name: params.id,
         label: merge(
             pageHeading,
-            { attributes: { id: params.id + "-label" } },
+            { attributes: { id: inputId + "-label" } },
             hmpoGetOptions(ctx, params, "label")
         ),
         hint: hmpoGetOptions(ctx, params, "hint", true),
         errorMessage: hmpoGetError(ctx, params),
         classes: params.classes,
         formGroup: params.formGroup,
-        attributes: hmpoGetAttributes(ctx, params, {}),
+        attributes: attributes,
         javascript: params.javascript if params.javascript is defined else true
     } %}
 

--- a/components/hmpo-file-upload/macro.njk
+++ b/components/hmpo-file-upload/macro.njk
@@ -3,6 +3,8 @@
     {%- set attributes = hmpoGetAttributes(ctx, params, {}) %}
     {%- set inputId = attributes.id if attributes.id else params.id %}
     {%- set attributes = attributes | delete("id") if attributes.id else attributes %}
+    {%- set labelId = inputId + "-label" %}
+    {%- set attributes = merge({ "aria-labelledby": labelId }, attributes) %}
 
     {%- set pageHeading = {
         isPageHeading: true,
@@ -14,7 +16,7 @@
         name: params.id,
         label: merge(
             pageHeading,
-            { attributes: { id: inputId + "-label" } },
+            { attributes: { id: labelId } },
             hmpoGetOptions(ctx, params, "label")
         ),
         hint: hmpoGetOptions(ctx, params, "hint", true),

--- a/components/hmpo-file-upload/macro.njk
+++ b/components/hmpo-file-upload/macro.njk
@@ -1,0 +1,28 @@
+{% macro hmpoFileUpload(ctx, params, base) %}
+    {%- set params = hmpoGetParams(ctx, params, base) %}
+
+    {%- set pageHeading = {
+        isPageHeading: true,
+        classes: "govuk-label--l"
+    } if params.isPageHeading %}
+
+    {%- set args = {
+        id: params.id,
+        name: params.id,
+        label: merge(
+            pageHeading,
+            { attributes: { id: params.id + "-label" } },
+            hmpoGetOptions(ctx, params, "label")
+        ),
+        hint: hmpoGetOptions(ctx, params, "hint", true),
+        errorMessage: hmpoGetError(ctx, params),
+        classes: params.classes,
+        formGroup: params.formGroup,
+        attributes: hmpoGetAttributes(ctx, params, {}),
+        javascript: params.javascript if params.javascript is defined else true
+    } %}
+
+    {%- from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+    {{ govukFileUpload(args) }}
+{% endmacro %}
+

--- a/components/hmpo-file-upload/macro.njk
+++ b/components/hmpo-file-upload/macro.njk
@@ -1,9 +1,7 @@
 {% macro hmpoFileUpload(ctx, params, base) %}
     {%- set params = hmpoGetParams(ctx, params, base) %}
     {%- set attributes = hmpoGetAttributes(ctx, params, {}) %}
-    {%- set inputId = attributes.id if attributes.id else params.id %}
-    {%- set attributes = attributes | delete("id") if attributes.id else attributes %}
-    {%- set labelId = inputId + "-label" %}
+    {%- set labelId = params.id + "-label" %}
     {%- set attributes = merge({ "aria-labelledby": labelId }, attributes) %}
 
     {%- set pageHeading = {
@@ -12,7 +10,7 @@
     } if params.isPageHeading %}
 
     {%- set args = {
-        id: inputId,
+        id: params.id,
         name: params.id,
         label: merge(
             pageHeading,

--- a/components/hmpo-form/macro.njk
+++ b/components/hmpo-form/macro.njk
@@ -2,9 +2,18 @@
 {% macro hmpoForm(ctx, params, base) %}
     {%- set params = hmpoGetParams(ctx, params, base) %}
 
+    {%- set fields = ctx("options.fields") or {} %}
+    {%- set hasFileUploadField = false %}
+    {%- for _, field in fields %}
+        {%- if field.type == "file-upload" %}
+            {%- set hasFileUploadField = true %}
+        {%- endif %}
+    {%- endfor %}
+
     {%- set attributes = hmpoGetAttributes(ctx, params, {
         action: params.action | default(ctx("action")) | default(""),
         method: params.method | default("POST"),
+        enctype: "multipart/form-data" if hasFileUploadField else undefined,
         autocomplete: "off",
         novalidate: "true",
         spellcheck: "false"

--- a/components/spec.form-template.js
+++ b/components/spec.form-template.js
@@ -156,46 +156,4 @@ describe('form template', () => {
         const $ = render({ template: 'form-template.njk' }, locals);
         expect($('label[for="uploadDocument"]').attr('class')).to.equal('govuk-label govuk-label--m');
     });
-
-    it('associates label with file input when a custom id attribute is provided', () => {
-        const locale = {
-            fields: {
-                uploadDocument: {
-                    label: 'Upload a document'
-                }
-            }
-        };
-
-        const locals = {
-            translate: (key, options = {}) => {
-                if (!Array.isArray(key)) key = [ key ];
-                const value = key.reduce((val, key) => {
-                    if (val !== undefined) return val;
-                    return key && key.split('.').reduce((val, part) => val && val[part], locale);
-                }, undefined);
-                if (value !== undefined) return value;
-                if (options.default) return options.default;
-                if (options.self === false) return undefined;
-                return '[' + key[0] + ']';
-            },
-            options: {
-                route: '/upload-route',
-                fields: {
-                    uploadDocument: {
-                        type: 'file-upload',
-                        attributes: {
-                            id: 'custom-upload-id',
-                            accept: 'application/pdf'
-                        }
-                    }
-                }
-            }
-        };
-
-        const $ = render({ template: 'form-template.njk' }, locals);
-        expect($('input[type="file"]').attr('id')).to.equal('custom-upload-id');
-        expect($('label.govuk-label').attr('for')).to.equal('custom-upload-id');
-        expect($('label.govuk-label').attr('id')).to.equal('custom-upload-id-label');
-        expect($('input[type="file"]').attr('aria-labelledby')).to.equal('custom-upload-id-label');
-    });
 });

--- a/components/spec.form-template.js
+++ b/components/spec.form-template.js
@@ -115,6 +115,8 @@ describe('form template', () => {
         expect($('form').attr('enctype')).to.equal('multipart/form-data');
         expect($('input#uploadDocument').attr('type')).to.equal('file');
         expect($('label[for="uploadDocument"]').attr('class')).to.equal('govuk-label govuk-label--l');
+        expect($('label[for="uploadDocument"]').attr('id')).to.equal('uploadDocument-label');
+        expect($('input#uploadDocument').attr('aria-labelledby')).to.equal('uploadDocument-label');
     });
 
     it('supports custom file-upload label classes from field config', () => {
@@ -193,5 +195,7 @@ describe('form template', () => {
         const $ = render({ template: 'form-template.njk' }, locals);
         expect($('input[type="file"]').attr('id')).to.equal('custom-upload-id');
         expect($('label.govuk-label').attr('for')).to.equal('custom-upload-id');
+        expect($('label.govuk-label').attr('id')).to.equal('custom-upload-id-label');
+        expect($('input[type="file"]').attr('aria-labelledby')).to.equal('custom-upload-id-label');
     });
 });

--- a/components/spec.form-template.js
+++ b/components/spec.form-template.js
@@ -114,5 +114,44 @@ describe('form template', () => {
         const $ = render({ template: 'form-template.njk' }, locals);
         expect($('form').attr('enctype')).to.equal('multipart/form-data');
         expect($('input#uploadDocument').attr('type')).to.equal('file');
+        expect($('label[for="uploadDocument"]').attr('class')).to.equal('govuk-label govuk-label--l');
+    });
+
+    it('supports custom file-upload label classes from field config', () => {
+        const locale = {
+            fields: {
+                uploadDocument: {
+                    label: 'Upload a document'
+                }
+            }
+        };
+
+        const locals = {
+            translate: (key, options = {}) => {
+                if (!Array.isArray(key)) key = [ key ];
+                const value = key.reduce((val, key) => {
+                    if (val !== undefined) return val;
+                    return key && key.split('.').reduce((val, part) => val && val[part], locale);
+                }, undefined);
+                if (value !== undefined) return value;
+                if (options.default) return options.default;
+                if (options.self === false) return undefined;
+                return '[' + key[0] + ']';
+            },
+            options: {
+                route: '/upload-route',
+                fields: {
+                    uploadDocument: {
+                        type: 'file-upload',
+                        label: {
+                            classes: 'govuk-label--m'
+                        }
+                    }
+                }
+            }
+        };
+
+        const $ = render({ template: 'form-template.njk' }, locals);
+        expect($('label[for="uploadDocument"]').attr('class')).to.equal('govuk-label govuk-label--m');
     });
 });

--- a/components/spec.form-template.js
+++ b/components/spec.form-template.js
@@ -79,4 +79,40 @@ describe('form template', () => {
         expect($('div#groupField input#groupField1').attr('type')).to.equal('text');
         expect($('div#groupField input#groupField2').attr('type')).to.equal('text');
     });
+
+    it('sets multipart encoding when file-upload fields are present', () => {
+        const locale = {
+            fields: {
+                uploadDocument: {
+                    label: 'Upload a document'
+                }
+            }
+        };
+
+        const locals = {
+            translate: (key, options = {}) => {
+                if (!Array.isArray(key)) key = [ key ];
+                const value = key.reduce((val, key) => {
+                    if (val !== undefined) return val;
+                    return key && key.split('.').reduce((val, part) => val && val[part], locale);
+                }, undefined);
+                if (value !== undefined) return value;
+                if (options.default) return options.default;
+                if (options.self === false) return undefined;
+                return '[' + key[0] + ']';
+            },
+            options: {
+                route: '/upload-route',
+                fields: {
+                    uploadDocument: {
+                        type: 'file-upload'
+                    }
+                }
+            }
+        };
+
+        const $ = render({ template: 'form-template.njk' }, locals);
+        expect($('form').attr('enctype')).to.equal('multipart/form-data');
+        expect($('input#uploadDocument').attr('type')).to.equal('file');
+    });
 });

--- a/components/spec.form-template.js
+++ b/components/spec.form-template.js
@@ -154,4 +154,44 @@ describe('form template', () => {
         const $ = render({ template: 'form-template.njk' }, locals);
         expect($('label[for="uploadDocument"]').attr('class')).to.equal('govuk-label govuk-label--m');
     });
+
+    it('associates label with file input when a custom id attribute is provided', () => {
+        const locale = {
+            fields: {
+                uploadDocument: {
+                    label: 'Upload a document'
+                }
+            }
+        };
+
+        const locals = {
+            translate: (key, options = {}) => {
+                if (!Array.isArray(key)) key = [ key ];
+                const value = key.reduce((val, key) => {
+                    if (val !== undefined) return val;
+                    return key && key.split('.').reduce((val, part) => val && val[part], locale);
+                }, undefined);
+                if (value !== undefined) return value;
+                if (options.default) return options.default;
+                if (options.self === false) return undefined;
+                return '[' + key[0] + ']';
+            },
+            options: {
+                route: '/upload-route',
+                fields: {
+                    uploadDocument: {
+                        type: 'file-upload',
+                        attributes: {
+                            id: 'custom-upload-id',
+                            accept: 'application/pdf'
+                        }
+                    }
+                }
+            }
+        };
+
+        const $ = render({ template: 'form-template.njk' }, locals);
+        expect($('input[type="file"]').attr('id')).to.equal('custom-upload-id');
+        expect($('label.govuk-label').attr('for')).to.equal('custom-upload-id');
+    });
 });


### PR DESCRIPTION
- This PR adds the improved file upload component from GDS:
  - https://design-system.service.gov.uk/components/file-upload/
- Updated README outlining usage
- Added supporting unit tests

**Screenshot of usage on Marriage Service Beta:**
<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/244701c2-93bc-403a-a6f0-86d377e0f7fa" />

**Accessibility testing using WAVE:**
<img width="1920" height="1399" alt="image" src="https://github.com/user-attachments/assets/46d3a785-f69a-4a7f-aa21-367ef74cecda" />
